### PR TITLE
Fix SwiftPM build

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.3
 
 import PackageDescription
 
@@ -6,7 +6,7 @@ let package = Package(
 	name: "SVGView",
 	platforms: [
 		.macOS(.v10_15),
-        .iOS(.v13),
+        .iOS(.v14),
         .watchOS(.v6)
     ],
     products: [
@@ -18,7 +18,8 @@ let package = Package(
     targets: [
     	.target(
     		name: "SVGView",
-            path: "Source"
+            path: "Source",
+            exclude: ["Info.plist"]
         )
     ],
     swiftLanguageVersions: [.v5]

--- a/Source/Helpers/SVGConstants.swift
+++ b/Source/Helpers/SVGConstants.swift
@@ -5,6 +5,8 @@
 //  Created by Alisa Mylnikova on 17/07/2020.
 //
 
+import Foundation
+
 open class SVGConstants {
 
     static let groupTags = ["svg", "g"]


### PR DESCRIPTION
* `NSRegularExpression` can't be resolved unless the `Foundation` import is added
* iOS 14 is required because of [`Color.cgColor`](https://developer.apple.com/documentation/swiftui/color/cgcolor)
* `Info.plist` is explicitly excluded to suppress an error message that it is unaccounted for