### PR TITLE
Allow opacity key in stylesheet to update fill and stroke opacities

### DIFF
--- a/SVGView.podspec
+++ b/SVGView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "SVGView"
-  s.version          = "1.0.4"
+  s.version          = "1.0.5"
   s.summary          = "SVGParser created with SwiftUI."
 
   s.homepage         = 'https://github.com/exyte/SVGView.git'

--- a/SVGViewTests/SVG12Tests.swift
+++ b/SVGViewTests/SVG12Tests.swift
@@ -56,6 +56,10 @@ class SVG12Tests: BaseTestCase {
     func testPaintFill04T() {
         compareToReference("paint-fill-04-t")
     }
+  
+    func testPaintFill06T() {
+        compareToReference("paint-fill-06-t")
+    }
 
     func testPaintStroke01T() {
         compareToReference("paint-stroke-01-t")

--- a/SVGViewTests/w3c/1.2T/refs/paint-fill-06-t.ref
+++ b/SVGViewTests/w3c/1.2T/refs/paint-fill-06-t.ref
@@ -1,0 +1,84 @@
+SVGViewport {
+	id: "svg-root",
+	viewBox: { width: 480, height: 360 },
+	contents: [
+		SVGGroup {
+			id: "test-body-content",
+			contents: [
+				SVGGroup {
+					id: "G1",
+					transform: [1, 0, 0, 1, 120, 30],
+					contents: [
+						SVGRect {
+							width: 90,
+							height: 70,
+							fill: "blue",
+							stroke: { fill: "red", width: 5 }
+						},
+						SVGRect {
+							x: 100,
+							width: 90,
+							height: 70,
+							fill: "blue",
+							stroke: { fill: "red", width: 5 }
+						},
+						SVGRect {
+							y: 80,
+							width: 90,
+							height: 70,
+							fill: "60% yellow",
+							stroke: { fill: "60% red", width: 2 }
+						},
+						SVGRect {
+							x: 100,
+							y: 80,
+							width: 90,
+							height: 70,
+							fill: "20% blue",
+							stroke: { fill: "90% yellow", width: 5 }
+						},
+						SVGGroup {
+							id: "G2",
+							contents: [
+								SVGRect {
+									y: 160,
+									width: 90,
+									height: 70,
+									fill: "yellow",
+									stroke: { fill: "red", width: 5 }
+								},
+								SVGRect {
+									x: 100,
+									y: 160,
+									width: 90,
+									height: 70,
+									fill: "yellow",
+									stroke: { fill: "red", width: 5 }
+								}
+							]
+						}
+					]
+				}
+			]
+		},
+		SVGGroup {
+			contents: [
+				SVGText {
+					id: "revision",
+					text: "$Revision: 1.6 $",
+					font: { name: "SVGFreeSansASCII,sans-serif", size: 32 },
+					fill: "black",
+					transform: [1, 0, 0, 1, 10, 340]
+				}
+			]
+		},
+		SVGRect {
+			id: "test-frame",
+			x: 1,
+			y: 1,
+			width: 478,
+			height: 358,
+			stroke: { fill: "black" }
+		}
+	]
+}

--- a/SVGViewTests/w3c/1.2T/svg/paint-fill-06-t.svg
+++ b/SVGViewTests/w3c/1.2T/svg/paint-fill-06-t.svg
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg version="1.2" baseProfile="tiny" xml:id="svg-root" width="100%" height="100%"
+  viewBox="0 0 480 360" xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xe="http://www.w3.org/2001/xml-events">
+  <!--======================================================================-->
+  <!--=  Copyright 2008 World Wide Web Consortium, (Massachusetts          =-->
+  <!--=  Institute of Technology, European Research Consortium for         =-->
+  <!--=  Informatics and Mathematics (ERCIM), Keio University).            =-->
+  <!--=  All Rights Reserved.                                              =-->
+  <!--=  See http://www.w3.org/Consortium/Legal/.                          =-->
+  <!--======================================================================-->
+  <SVGTestCase xmlns="http://www.w3.org/2000/02/svg/testsuite/description/"
+    reviewer="NR" owner="TT" desc="Test inheritance of painting properties." status="accepted"
+    approved="yes"
+    version="$Revision: 1.6 $" testname="$RCSfile: paint-fill-04-t.svg,v $">
+    <d:OperatorScript xmlns:d="http://www.w3.org/2000/02/svg/testsuite/description/" xmlns="http://www.w3.org/1999/xhtml">
+      <p>
+        This tests inheritance of three properties: "fill", "stroke" and "stroke-width". There is a "g" element (id="G1")
+        which sets fill="blue", stroke="red", and stroke-width="5". The first two rectangles on top should inherit all
+        those properties.
+        The middle left rectangle has fill="yellow", opacity=".6" and stroke-width="2", it should have 
+        60% opacity for both fill and stroke. The middle rectangle on the right has stroke="yellow", fill-opacity="0.2",
+        stroke-opacity=0.9, it should inherit show fill with 20% opacity, and stroke with 90% opacity.
+        The bottom two rectangles are in another "g" element (id="G2") which
+        is a child of "G1". "G2" sets fill="yellow". It should inherit the stroke and stroke width from the parent "G1".
+        The two bottom rectangles set no fill or stroke properties, they should inherit through the parents, stroke="red"
+        and stroke-width="5".
+      </p>
+      <p>The rendered picture should match the reference image, except for possible variations in the labeling text (per CSS2 rules).</p>
+      <p>
+        The test uses the "rect" element, as well as basic fill (solid primary colors), stroke (black 1-pixel lines),
+        font-family (Arial) and font-size properties.
+      </p>
+    </d:OperatorScript>
+  </SVGTestCase>
+  <title xml:id="test-title">$RCSfile: paint-fill-04-t.svg,v $</title>
+  <defs>
+    <font-face font-family="SVGFreeSansASCII" unicode-range="U+0-7F">
+      <font-face-src>
+        <font-face-uri xlink:href="../images/SVGFreeSans.svg#ascii" />
+      </font-face-src>
+    </font-face>
+  </defs>
+  <g xml:id="test-body-content" font-family="SVGFreeSansASCII,sans-serif" font-size="18">
+    <g xml:id="G1" fill="blue" stroke="red" stroke-width="5" transform="translate(120,30)">
+      <rect x="0" y="0" width="90" height="70" />
+      <rect x="100" y="0" width="90" height="70" />
+      <rect x="0" y="80" width="90" height="70" fill="yellow" stroke-width="2" style="opacity:.6" />
+      <rect x="100" y="80" width="90" height="70" stroke="yellow" style="fill-opacity:.2; stroke-opacity:0.9" />
+      <g xml:id="G2" fill="yellow">
+        <rect x="0" y="160" width="90" height="70" />
+        <rect x="100" y="160" width="90" height="70" />
+      </g>
+    </g>
+  </g>
+  <g font-family="SVGFreeSansASCII,sans-serif" font-size="32">
+    <text xml:id="revision" x="10" y="340" stroke="none" fill="black">$Revision: 1.6 $</text>
+  </g>
+  <rect xml:id="test-frame" x="1" y="1" width="478" height="358" fill="none" stroke="#000" />
+  <!-- comment out this watermark once the test is approved -->
+  <!--<g xml:id="draft-watermark">
+    <rect x="1" y="1" width="478" height="20" fill="red" stroke="black" stroke-width="1"/>
+    <text font-family="SVGFreeSansASCII,sans-serif" font-weight="bold" font-size="20" x="240"
+      text-anchor="middle" y="18" stroke-width="0.5" stroke="black" fill="white">DRAFT</text>
+  </g>-->
+</svg>

--- a/Source/Parser/SVG/SVGParserBasics.swift
+++ b/Source/Parser/SVG/SVGParserBasics.swift
@@ -9,9 +9,14 @@ import SwiftUI
 
 extension SVGHelper {
 
-    static func parseDouble(_ attributes: [String: String], _ key: String, defaultValue: Double = 0) -> Double {
+  static func parseDouble(_ attributes: [String: String], _ key: String, alternativeKeys: [String] = [], defaultValue: Double = 0) -> Double {
         if let value = attributes[key], let result = doubleFromString(value) {
             return result
+        }
+        for alternativeKey in alternativeKeys {
+            if let value = attributes[alternativeKey], let result = doubleFromString(value) {
+                return result
+            }
         }
         return defaultValue
     }
@@ -62,14 +67,14 @@ extension SVGHelper {
         return points
     }
 
-    static func parseOpacity(_ attributes: [String: String], _ key: String) -> Double {
-        let opacity = parseDouble(attributes, key, defaultValue: 1)
+    static func parseOpacity(_ attributes: [String: String], _ key: String, alternativeKeys: [String] = []) -> Double {
+        let opacity = parseDouble(attributes, key, alternativeKeys: alternativeKeys, defaultValue: 1)
         return min(max(opacity, 0), 1)
     }
 
     static func parseFill(_ style: [String: String], _ index: SVGIndex) -> SVGPaint? {
         guard let colorString = style["fill"] else {
-            return SVGColor.black.opacity(parseOpacity(style, "fill-opacity"))
+            return SVGColor.black.opacity(parseOpacity(style, "fill-opacity", alternativeKeys: ["opacity"]))
         }
         return parseFillInternal(colorString, style, index)
     }
@@ -88,7 +93,7 @@ extension SVGHelper {
             }
         }
         if let color = parseColor(colorString, style) {
-            return color.opacity(parseOpacity(style, "fill-opacity"))
+            return color.opacity(parseOpacity(style, "fill-opacity", alternativeKeys: ["opacity"]))
         }
         
         return .none

--- a/Source/Parser/SVG/SVGParserPrimitives.swift
+++ b/Source/Parser/SVG/SVGParserPrimitives.swift
@@ -27,7 +27,7 @@ public class SVGHelper: NSObject {
         }
 
         return SVGStroke(
-            fill: fill.opacity(SVGHelper.parseOpacity(style, "stroke-opacity")),
+            fill: fill.opacity(SVGHelper.parseOpacity(style, "stroke-opacity", alternativeKeys: ["opacity"])),
             width: parseCGFloat(style, "stroke-width", defaultValue: 1),
             cap: getStrokeCap(style),
             join: getStrokeJoin(style),


### PR DESCRIPTION
In the stylesheet of an SVG, we can have `opacity`, `fill-opacity`, and `stroke-opacity`. When `opacity` is used, it should affect both fill and stroke if `fill-opacity` and `stroke-opacity` are absent. Previously `SVGView` only supported `fill-opacity` and `stroke-opacity` from the stylesheet but not `opacity`.

Also added a sample SVG file to demonstrate that, and included it in the unit test.
