### PR TITLE
Add `import Combine` to all files which uses @Published

### DIFF
--- a/Source/Model/Images/SVGDataImage.swift
+++ b/Source/Model/Images/SVGDataImage.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Combine
 
 public class SVGDataImage: SVGImage, ObservableObject {
 

--- a/Source/Model/Nodes/SVGGroup.swift
+++ b/Source/Model/Nodes/SVGGroup.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Combine
 
 public class SVGGroup: SVGNode, ObservableObject {
 

--- a/Source/Model/Nodes/SVGImage.swift
+++ b/Source/Model/Nodes/SVGImage.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Combine
 
 public class SVGImage: SVGNode {
 

--- a/Source/Model/Nodes/SVGNode.swift
+++ b/Source/Model/Nodes/SVGNode.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Combine
 
 public class SVGNode: SerializableElement {
 

--- a/Source/Model/Nodes/SVGShape.swift
+++ b/Source/Model/Nodes/SVGShape.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Combine
 
 public class SVGShape: SVGNode {
 

--- a/Source/Model/Nodes/SVGText.swift
+++ b/Source/Model/Nodes/SVGText.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Combine
 
 public class SVGText: SVGNode, ObservableObject {
 

--- a/Source/Model/Nodes/SVGViewport.swift
+++ b/Source/Model/Nodes/SVGViewport.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Combine
 
 class SVGViewport: SVGGroup {
 

--- a/Source/Model/Shapes/SVGCircle.swift
+++ b/Source/Model/Shapes/SVGCircle.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Combine
 
 public class SVGCircle: SVGShape, ObservableObject {
 

--- a/Source/Model/Shapes/SVGEllipse.swift
+++ b/Source/Model/Shapes/SVGEllipse.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Combine
 
 public class SVGEllipse: SVGShape, ObservableObject {
 

--- a/Source/Model/Shapes/SVGLine.swift
+++ b/Source/Model/Shapes/SVGLine.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Combine
 
 public class SVGLine: SVGShape, ObservableObject {
 

--- a/Source/Model/Shapes/SVGPath.swift
+++ b/Source/Model/Shapes/SVGPath.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Combine
 
 public class SVGPath: SVGShape, ObservableObject {
 

--- a/Source/Model/Shapes/SVGPolygon.swift
+++ b/Source/Model/Shapes/SVGPolygon.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Combine
 
 public class SVGPolygon: SVGShape, ObservableObject {
 

--- a/Source/Model/Shapes/SVGPolyline.swift
+++ b/Source/Model/Shapes/SVGPolyline.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Combine
 
 public class SVGPolyline: SVGShape, ObservableObject {
 

--- a/Source/Model/Shapes/SVGRect.swift
+++ b/Source/Model/Shapes/SVGRect.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Combine
 
 public class SVGRect: SVGShape, ObservableObject {
 

--- a/Source/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/Source/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,6 +1,0 @@
-{
-  "info" : {
-    "author" : "xcode",
-    "version" : 1
-  }
-}


### PR DESCRIPTION
`@Published` is a part of Combine, not importing Combine everywhere its used will cause a [Unknown attribute 'Combine.Published'](https://stackoverflow.com/questions/69473492/xcode-xcframework-errors-like-unknown-attribute-combine-published) when compiled as a XCFramework.

This PR adds `import Combine` to all relevant files.