### PR TITLE
Fixed duplication of gestures in makeOneGesture

### DIFF
--- a/Source/UI/UIExtensions.swift
+++ b/Source/UI/UIExtensions.swift
@@ -58,6 +58,9 @@ extension View {
     }
 
     func makeOneGesture(model: SVGNode) -> some Gesture {
+        guard model.gestures.count > 1 else {
+            return model.gestures.first
+        }
         var result = model.gestures.first
         for gesture in model.gestures {
             result = AnyGesture(SimultaneousGesture(result, gesture).map { _ in () })


### PR DESCRIPTION
The implementation of `View.makeOneGesture()` in 1.0.4 has a bug which results in duplication of gestures when only one `Gesture` has been added to the view.

The impact of this bug can be observed with the following sample code:

```swift
@State var isEnabled: Bool = true
let logger = Logger()

if let part = view.getNode(byId: "part") {
    part.onTapGesture {
       isEnabled.toggle()
       logger.debug("isEnabled = \(isEnabled)")
    }
}
```

Tapping on the node once will cause the code block to execute twice; in the above example, this sets `isEnabled` to true and then false.

This PR adds a guard to abort creating a `SimultaneousGesture` if only one gesture exists.