### PR TITLE
'cgColor' is only available in watchOS 7.0 or newer

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
 	platforms: [
 		.macOS(.v11),
         .iOS(.v14),
-        .watchOS(.v6)
+        .watchOS(.v7)
     ],
     products: [
     	.library(


### PR DESCRIPTION
https://github.com/exyte/SVGView/issues/29