### PR TITLE
Make some internal objects public to use the parsed results available outside of the library

### DIFF
--- a/Source/Model/Nodes/SVGViewport.swift
+++ b/Source/Model/Nodes/SVGViewport.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import Combine
 
-class SVGViewport: SVGGroup {
+public class SVGViewport: SVGGroup {
 
     @Published public var width: SVGLength {
         willSet {

--- a/Source/Model/Primitives/SVGColor.swift
+++ b/Source/Model/Primitives/SVGColor.swift
@@ -87,7 +87,7 @@ public class SVGColor: SVGPaint {
         return (value >> 24) & 0xff
     }
 
-    var opacity: Double {
+    public var opacity: Double {
         return Double(a) / 255
     }
 

--- a/Source/Model/Primitives/SVGLength.swift
+++ b/Source/Model/Primitives/SVGLength.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-enum SVGLength {
+public enum SVGLength {
 
     case percent(CGFloat)
     case pixels(CGFloat)
@@ -29,7 +29,7 @@ enum SVGLength {
         }
     }
 
-    func toPixels(total: CGFloat) -> CGFloat {
+    public func toPixels(total: CGFloat) -> CGFloat {
         switch self {
         case let .percent(percent):
             return total * percent / 100.0
@@ -38,7 +38,7 @@ enum SVGLength {
         }
     }
 
-    func toString() -> String {
+    public func toString() -> String {
         switch(self) {
         case let .percent(percent):
             return "\(percent.serialize())%"

--- a/Source/Parser/SVG/SVGPathReader.swift
+++ b/Source/Parser/SVG/SVGPathReader.swift
@@ -317,7 +317,7 @@ class PathReader {
 
 extension SVGPath {
 
-    func toBezierPath() -> MBezierPath {
+    public func toBezierPath() -> MBezierPath {
 
         func calcAngle(ux: CGFloat, uy: CGFloat, vx: CGFloat, vy: CGFloat) -> CGFloat {
             let sign = copysign(1, ux * vy - uy * vx)


### PR DESCRIPTION
While `SVGParser.parse(data:)` can be called by library users, the parsed result, `SVGNode`, is currently not fully usable since some types are internal.

This PR fixes some of the above problems.