### PR TITLE
tvOS TapGesture Availability

### DIFF
--- a/Source/Model/Nodes/SVGNode.swift
+++ b/Source/Model/Nodes/SVGNode.swift
@@ -34,6 +34,7 @@ public class SVGNode: SerializableElement {
         return self.id == id ? self : .none
     }
 
+    @available(tvOS 16.0, *)
     public func onTapGesture(_ count: Int = 1, tapClosure: @escaping ()->()) {
         let newGesture = TapGesture(count: count).onEnded {
             tapClosure()


### PR DESCRIPTION
`TapGesture` supports tvOS 16, while the package supports 14. Simply annotates the method for compatibility.