### PR TITLE
fix : parse radial gradient when the scale is not equal

### DIFF
--- a/Source/Parser/SVG/SVGIndex.swift
+++ b/Source/Parser/SVG/SVGIndex.swift
@@ -148,10 +148,10 @@ class SVGIndex {
 
             let xScale = abs(transform.a)
             let yScale = abs(transform.d)
-            if xScale == yScale {
+            if xScale <= yScale {
                 r *= xScale
             } else {
-                print("SVG parsing error. No oval radial gradients supported")
+                r *= yScale
             }
 
             let point2 = CGPoint(x: fx, y: fy).applying(transform)


### PR DESCRIPTION
Fix a parseRadialGradient when the scale is not equal.

**Sample File**
![sample](https://github.com/exyte/SVGView/assets/8283886/9eee584e-bf76-4f08-a4a5-91c614b2399e)

**Before Output in watchOS**
![before](https://github.com/exyte/SVGView/assets/8283886/9948fd6c-58b8-46eb-87ba-99700281385c)

**After Output in watchOS**
![after](https://github.com/exyte/SVGView/assets/8283886/39f760ac-4d0a-4842-ae5a-67df15794211)
