### PR TITLE
fix : fill-opacity is applied to the overlay, if the fill is a gradient paint

### DIFF
--- a/Source/Model/Primitives/SVGGradient.swift
+++ b/Source/Model/Primitives/SVGGradient.swift
@@ -83,6 +83,7 @@ public class SVGLinearGradient: SVGGradient {
                     .frame(width: width, height: height)
                     .offset(x: bounds.minX, y: bounds.minY)
                     .mask(view)
+                    .opacity(opacity)
             )
     }
 
@@ -130,6 +131,7 @@ public class SVGRadialGradient: SVGGradient {
                                         height: userSpace ? 1 : height/minimum))
                     .offset(x: bounds.minX, y: bounds.minY)
                     .mask(view)
+                    .opacity(opacity)
             )
     }
 
@@ -151,10 +153,16 @@ public class SVGGradient: SVGPaint, Equatable {
 
     public let userSpace: Bool
     public let stops: [SVGStop]
+    public private(set) var opacity: Double = 1.0
 
     public init(userSpace: Bool = false, stops: [SVGStop] = []) {
         self.userSpace = userSpace
         self.stops = stops
+    }
+
+    public override func opacity(_ opacity: Double) -> SVGGradient {
+        self.opacity = opacity
+        return self
     }
 
 }

--- a/Source/Parser/SVG/SVGParserBasics.swift
+++ b/Source/Parser/SVG/SVGParserBasics.swift
@@ -89,7 +89,7 @@ extension SVGHelper {
     static func parseFillInternal(_ colorString: String, _ style: [String: String], _ index: SVGIndex) -> SVGPaint? {
         if let colorId = SVGHelper.parseIdFromUrl(colorString) {
             if let paint = index.paint(by: colorId) {
-                return paint
+                return paint.opacity(parseOpacity(style, "fill-opacity", alternativeKeys: ["opacity"]))
             }
         }
         if let color = parseColor(colorString, style) {


### PR DESCRIPTION
If the fill is a gradient paint, this will be displayed as a overlay.
I think, the fill-opacity will be applied to the overlay