### PR TITLE
Added font-weight support

### DIFF
--- a/Source/Model/Primitives/SVGFont.swift
+++ b/Source/Model/Primitives/SVGFont.swift
@@ -13,12 +13,33 @@ public class SVGFont: SerializableBlock {
     }
 
     public func toSwiftUI() -> Font {
-        return Font.custom(name, size: size)//.weight(fontWeight)
+        return Font.custom(name, size: size).weight(fontWeight(from: weight))
     }
 
     func serialize(_ serializer: Serializer) {
         serializer.add("name", name, "Serif").add("size", size, 16).add("weight", weight, "normal")
     }
+    
+    private func fontWeight(from: String) -> Font.Weight {
+        // TODO: lighter and bolder are context-based, this is temporary.
+        switch from {
+        case "lighter": return .light
+        case  "normal": return .regular
+        case    "bold": return .bold
+        case  "bolder": return .black
+        case "100": return .ultraLight
+        case "200": return .thin
+        case "300": return .light
+        case "400": return .regular
+        case "500": return .medium
+        case "600": return .semibold
+        case "700": return .bold
+        case "800": return .heavy
+        case "900": return .black
+        default:    return .regular
+        }
+    }
+
 }
 
 

--- a/Source/UI/MBezierPath+Extension_macOS.swift
+++ b/Source/UI/MBezierPath+Extension_macOS.swift
@@ -52,6 +52,8 @@ extension MBezierPath {
 
             case .closePath:
                 path.closeSubpath()
+            case .cubicCurveTo: fallthrough
+            case .quadraticCurveTo: fallthrough
             @unknown default:
                 fatalError("Type of element undefined")
             }


### PR DESCRIPTION
Added [font-weight](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight) support with a note for `lighter` and `bolder` which are context related and must be fixed in a future patch (that's why we use a member function rather than an extension on `Font.Weight`).

Fixed the exhaustive switch warning in `MBezierPath` as well.