### PR TITLE
Fix linear gradient fill overlay positioning

### DIFF
--- a/Source/Model/Primitives/SVGGradient.swift
+++ b/Source/Model/Primitives/SVGGradient.swift
@@ -81,7 +81,7 @@ public class SVGLinearGradient: SVGGradient {
                             .scaleEffect(CGSize(width: width/maximum, height: height/maximum))
                     }
                     .frame(width: width, height: height)
-                    .offset(x: bounds.minX, y: bounds.minY)
+                    .offset(x: frame.minX, y: frame.minY)
                     .mask(view)
             )
     }


### PR DESCRIPTION
Current code always sets the overlay to the point 0,0 which may lead to incorrect behavior 