### PR TITLE
Allow 'stop' elements with CSS syle attributes to be parsed

### DIFF
--- a/Source/Parser/SVG/SVGIndex.swift
+++ b/Source/Parser/SVG/SVGIndex.swift
@@ -177,12 +177,16 @@ class SVGIndex {
     private func parseStop(_ element: XMLElement, _ style: [String: String]) -> SVGStop? {
         let offset = getDoubleValueFromPercentage(element, attribute: "offset")
 
+        // Explode any CSS styles and merge with XML style attributes
+        let cssAttributes = SVGParser.getStyleAttributes(xml: element, index: self)
+        let attributes = element.attributes.merging(cssAttributes) { current, _ in current }
+
         var opacity: Double = 1
-        if let stopOpacity = element.attributes["stop-opacity"], let doubleValue = Double(stopOpacity) {
+        if let stopOpacity = attributes["stop-opacity"], let doubleValue = Double(stopOpacity) {
             opacity = doubleValue
         }
         var color = SVGColor.black.opacity(opacity)
-        if let stopColor = element.attributes["stop-color"], let clr = SVGHelper.parseColor(stopColor, style) {
+        if let stopColor = attributes["stop-color"], let clr = SVGHelper.parseColor(stopColor, style) {
             color = clr.opacity(opacity)
         }
         return SVGStop(color: color, offset: offset)


### PR DESCRIPTION
Allows parsing of gradient stops that use CSS styles instead of XML style attributes.

Ex:
```
    <linearGradient spreadMethod="pad" id="gradient" x1="0%" y1="0%" x2="80%" y2="116%">
      <stop offset="2%" style="stop-color:#09326C;stop-opacity:1;" />
      <stop offset="100%" style="stop-color:#CD519D;stop-opacity:1;" />
    </linearGradient>
```
where `stop-color` and `stop-opacity` are defined on the `style` attribute.