### PR TITLE
Fix text rotation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,6 +20,12 @@ let package = Package(
     		name: "SVGView",
             path: "Source",
             exclude: ["Info.plist"]
+        ),
+        .testTarget(
+            name: "SVGViewTests",
+            dependencies: ["SVGView"],
+            path: "SVGViewTests",
+            resources: [.copy("w3c")]
         )
     ],
     swiftLanguageVersions: [.v5]

--- a/SVGViewTests/BaseTestCase.swift
+++ b/SVGViewTests/BaseTestCase.swift
@@ -15,7 +15,7 @@ class BaseTestCase : XCTestCase {
     }
 
     func compareToReference(_ fileName: String) {
-        let bundle = Bundle(for: type(of: self))
+        let bundle = Bundle.module
         let svgURL = bundle.url(forResource: fileName, withExtension: "svg", subdirectory: "w3c/\(dir)/svg/")!
         let refURL = bundle.url(forResource: fileName, withExtension: "ref", subdirectory: "w3c/\(dir)/refs/")!
 

--- a/SVGViewTests/SVGRefGenerator.swift
+++ b/SVGViewTests/SVGRefGenerator.swift
@@ -147,7 +147,7 @@ class SVGRefGenerator: XCTestCase {
     }
 
     func createReference(name: String, version: String) {
-        let bundle = Bundle(for: type(of: self))
+        let bundle = Bundle.module
         let url = bundle.url(forResource: name, withExtension: "svg", subdirectory: version)!
         let versionNumber = String(version.split(separator: "/")[1])
         let testDirectory = getTestDir(version: versionNumber)

--- a/Source/Model/Nodes/SVGText.swift
+++ b/Source/Model/Nodes/SVGText.swift
@@ -58,6 +58,7 @@ struct SVGTextView: View {
            .alignmentGuide(VerticalAlignment.top) { d in d[VerticalAlignment.firstTextBaseline] }
            .position(x: 0, y: 0) // just to specify that positioning is global, actual coords are in transform
            .apply(paint: fill)
+           .frame(alignment: .topLeading)
            .transformEffect(model.transform)
            .frame(alignment: .topLeading)
     }


### PR DESCRIPTION
This PR does two things:
- adjusts the SPM package to allow the tests to run under SPM (the change introduces no new failures), and
- fixes a bug in how rotated text renders in SwiftUI.

Text rotations weren't being applied to the SwiftUI view in quite the same way as in the SVG renderer (the transformation wasn't using the same origin coordinates).

Take the small example SVG:

```
<svg xmlns="http://www.w3.org/2000/svg"
xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" class="marks"
width="100" height="100" viewBox="0 0 100 100">
<g transform="translate(10,10)">
<rect width="65" height="65" fill="pink"/>
<text text-anchor="start" transform="translate(2,6) rotate(45)" font-family="sans-serif"
font-size="10px" fill="#000" opacity="1">AAAAAAAAAAAA</text>
</g>
</svg>
```

| SVGView before this fix | Rendered in your browser | Screenshot from SVG viewer Gapplin | SVGView after this fix |
|--------|--------|--------|--------|
| <img width="200" alt="spec rotated-text" src="https://github.com/user-attachments/assets/0c5bc659-a38f-4a6e-aafe-dfebcb580ee6" /> | ![rotated-text](https://github.com/user-attachments/assets/9a830d6d-c478-4532-a254-38634213f2ae) | <img width="114" alt="Screenshot 2025-01-24 at 13 35 03" src="https://github.com/user-attachments/assets/62fa4843-1507-4f8f-ad5d-b3d6a9958b14" /> | <img width="200" alt="spec rotated-text" src="https://github.com/user-attachments/assets/e75410d7-2aed-486b-a57b-651d8246ba44" /> |
