### PR TITLE
Fix the discontinuity when appending the path

### DIFF
--- a/Source/Parser/SVG/Attributes/SVGFontSizeAttribute.swift
+++ b/Source/Parser/SVG/Attributes/SVGFontSizeAttribute.swift
@@ -5,7 +5,7 @@
 //  Created by Yuri Strot on 29.05.2022.
 //
 
-import CoreGraphics
+import Foundation
 
 class SVGFontSizeAttribute: SVGDefaultAttribute<CGFloat> {
 

--- a/Source/Parser/SVG/Attributes/SVGLengthAttribute.swift
+++ b/Source/Parser/SVG/Attributes/SVGLengthAttribute.swift
@@ -5,7 +5,7 @@
 //  Created by Yuri Strot on 29.05.2022.
 //
 
-import CoreGraphics
+import Foundation
 
 class SVGLengthAttribute: SVGDefaultAttribute<CGFloat> {
     

--- a/Source/Parser/SVG/Elements/SVGShapeParser.swift
+++ b/Source/Parser/SVG/Elements/SVGShapeParser.swift
@@ -5,7 +5,7 @@
 //  Created by Yuri Strot on 29.05.2022.
 //
 
-import CoreGraphics
+import Foundation
 
 class SVGShapeParser: SVGBaseElementParser {
 

--- a/Source/Parser/SVG/Elements/SVGStructureParsers.swift
+++ b/Source/Parser/SVG/Elements/SVGStructureParsers.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import CoreGraphics
 
 class SVGViewportParser: SVGGroupParser {
 

--- a/Source/Parser/SVG/Primitives/SVGLengthParser.swift
+++ b/Source/Parser/SVG/Primitives/SVGLengthParser.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import CoreGraphics
 
 enum SVGLengthAxis {
 

--- a/Source/Parser/SVG/SVGContext.swift
+++ b/Source/Parser/SVG/SVGContext.swift
@@ -5,7 +5,7 @@
 //  Created by Yuri Strot on 26.05.2022.
 //
 
-import CoreGraphics
+import Foundation
 
 protocol SVGContext {
 

--- a/Source/Parser/SVG/SVGParserExtensions.swift
+++ b/Source/Parser/SVG/SVGParserExtensions.swift
@@ -5,7 +5,7 @@
 //  Created by Yuri Strot on 25.05.2022.
 //
 
-import CoreGraphics
+import Foundation
 
 extension CGFloat {
 

--- a/Source/Parser/SVG/SVGPathReader.swift
+++ b/Source/Parser/SVG/SVGPathReader.swift
@@ -560,13 +560,13 @@ extension SVGPath {
                 bezierPath.addArc(withCenter: CGPoint(x: cx, y: cy), radius: CGFloat(w / 2), startAngle: extent, endAngle: end, clockwise: arcAngle >= 0)
             } else {
                 let maxSize = CGFloat(max(w, h))
-                let path = MBezierPath(arcCenter: CGPoint.zero, radius: maxSize / 2, startAngle: extent, endAngle: end, clockwise: arcAngle >= 0)
-
                 var transform = CGAffineTransform(translationX: cx, y: cy)
                 transform = transform.rotated(by: CGFloat(rotation))
-                path.apply(transform.scaledBy(x: CGFloat(w) / maxSize, y: CGFloat(h) / maxSize))
-
-                bezierPath.append(path)
+                transform = transform.scaledBy(x: CGFloat(w) / maxSize, y: CGFloat(h) / maxSize)
+                let mutablePath = CGMutablePath()
+                mutablePath.addPath(bezierPath.cgPath)
+                mutablePath.addArc(center: .zero, radius: maxSize / 2, startAngle: extent, endAngle: end, clockwise: arcAngle < 0, transform: transform)
+                bezierPath.cgPath = mutablePath
             }
         }
 

--- a/Source/Parser/SVG/Settings/SVGScreen.swift
+++ b/Source/Parser/SVG/Settings/SVGScreen.swift
@@ -5,7 +5,7 @@
 //  Created by Yuri Strot on 27.05.2022.
 //
 
-import CoreGraphics
+import Foundation
 
 struct SVGScreen {
 

--- a/Source/Parser/SVG/Settings/SVGSettings.swift
+++ b/Source/Parser/SVG/Settings/SVGSettings.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import CoreGraphics
 
 public struct SVGSettings {
 

--- a/Source/Serialization/Serializer.swift
+++ b/Source/Serialization/Serializer.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import CoreGraphics
 
 class Serializer {
 


### PR DESCRIPTION
Using the `UIBezierPath` method `append(_ bezierPath: UIBezierPath)` does not automatically connect two paths, even if the endpoint of the first path matches the start point of the second path.

To ensure continuity, in the case of an elliptical arc, the `CGMutablePath` method `addArc(center: CGPoint, radius: CGFloat, startAngle: CGFloat, endAngle: CGFloat, clockwise: Bool, transform: CGAffineTransform = .identity)` should be used.

Current issue:
![pm2](https://github.com/user-attachments/assets/5db932dc-c860-46d6-882e-b00bdb4e81c7)

Expect:
![pm2](https://cdn.simpleicons.org/pm2?size=300)
