### PR TITLE
fix: remove viewport clipping to prevent stroke cutoff

### DIFF
--- a/Source/Model/Nodes/SVGViewport.swift
+++ b/Source/Model/Nodes/SVGViewport.swift
@@ -69,7 +69,7 @@ struct SVGViewportView: View {
                 .transformEffect(getTransform(viewBox: viewBox, size: size))
         }
         .frame(idealWidth: model.width.ideal, idealHeight: model.height.ideal)
-        .clipped()
+        // Removed .clipped() to allow strokes to render beyond viewport bounds
     }
 
     private func getViewBox(size: CGSize) -> CGRect {


### PR DESCRIPTION
When SVG elements have strokes that extend beyond their viewport bounds, the `.clipped()` modifier would cut them off. This change allows strokes to render fully outside their nominal bounds.

## Problem
When using SVG shapes with strokes, especially with larger stroke widths, the strokes can get clipped at the viewport boundaries. This is because the `.clipped()` modifier in `SVGViewportView` forces the content to stay within its frame.

## Solution
Remove the `.clipped()` modifier from `SVGViewportView` to allow strokes to render beyond the viewport bounds. This maintains the same viewport sizing and transformation behavior while allowing strokes to be fully visible.

## Testing
Tested with SVG shapes using various stroke widths and confirmed that:
- Strokes now render completely without being cut off at the edges
- The basic viewport sizing and transformation behavior remains unchanged
- SVG content still respects the frame size for layout purposes