### PR TITLE
draft: cached svg view implementation

### DIFF
--- a/Source/Model/Nodes/SVGCacheModel.swift
+++ b/Source/Model/Nodes/SVGCacheModel.swift
@@ -1,0 +1,33 @@
+//
+//  SVGCacheModel.swift
+//  SVGView
+//
+//  Created by Michael Gavrilenko on 10.08.2025.
+//
+
+import Foundation
+
+final class SVGCache {
+    static let shared = SVGCache()
+
+    private let cache = NSCache<NSURL, SVGNode>()
+
+    private init() {}
+
+    func getNode(for url: URL) -> SVGNode? {
+        let key = url as NSURL
+
+        if let cachedNode = cache.object(forKey: key) {
+            return cachedNode
+        }
+
+        print("SVGCache: Parsing and caching new node for \(url.lastPathComponent)")
+        guard let newNode = SVGParser.parse(contentsOf: url) else {
+            return nil
+        }
+
+        cache.setObject(newNode, forKey: key)
+
+        return newNode
+    }
+}

--- a/Source/Parser/SVG/SVGCachedView.swift
+++ b/Source/Parser/SVG/SVGCachedView.swift
@@ -1,0 +1,49 @@
+//
+//  SVGCachedView.swift
+//  SVGView
+//
+//  Created by Michael Gavrilenko on 10.08.2025.
+//
+
+import SwiftUI
+
+public struct CachedSVGView: View {
+    public let svg: SVGNode?
+
+    public init(contentsOf url: URL) {
+        svg = SVGCache.shared.getNode(for: url)
+    }
+
+    @available(*, deprecated, message: "Use (contentsOf:) initializer instead")
+    public init(fileURL: URL) {
+        svg = SVGCache.shared.getNode(for: fileURL)
+    }
+
+    public init(data: Data) {
+        svg = SVGParser.parse(data: data)
+    }
+
+    public init(string: String) {
+        svg = SVGParser.parse(string: string)
+    }
+
+    public init(stream: InputStream) {
+        svg = SVGParser.parse(stream: stream)
+    }
+
+    public init(xml: XMLElement) {
+        svg = SVGParser.parse(xml: xml)
+    }
+
+    public init(svg: SVGNode) {
+        self.svg = svg
+    }
+
+    public func getNode(byId id: String) -> SVGNode? {
+        svg?.getNode(byId: id)
+    }
+
+    public var body: some View {
+        svg?.toSwiftUI()
+    }
+}


### PR DESCRIPTION
Implemented a draft cached view (only for url and svg).

Can be considered as basis of your own implementation. In other case - can be finished to maintain the project. (commit frequency suggests that thats unrealistic ;))