### PR TITLE
Add tvOS platform support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.7
 
 import PackageDescription
 
@@ -7,6 +7,7 @@ let package = Package(
 	platforms: [
 		.macOS(.v11),
         .iOS(.v14),
+        .tvOS(.v16),
         .watchOS(.v7)
     ],
     products: [


### PR DESCRIPTION
## Summary

- Bumps `swift-tools-version` from 5.3 to 5.7 (required for `.tvOS` platform specifier with version ≥ 16)
- Adds `.tvOS(.v16)` to Package.swift platforms

## Rationale

SVGView's SwiftUI code compiles for tvOS without modification. However, without `.tvOS` declared in the package platforms, downstream packages that depend on SVGView cannot cleanly declare tvOS support themselves.

The minimum tvOS version is set to 16.0 because `TapGesture` (used in `SVGNode.swift:38`) requires tvOS 16.0+.

The `swift-tools-version` bump from 5.3 to 5.7 is necessary because `.tvOS(.v16)` is not available in the 5.3 tools version. This should not affect existing iOS, macOS, or watchOS consumers.

## Motivation

This enables SVGView to be used as a dependency in tvOS apps, specifically to support [LaTeXSwiftUI](https://github.com/colinc86/LaTeXSwiftUI) on tvOS (see colinc86/LaTeXSwiftUI#77).

## Test plan

- [x] Build for tvOS Simulator target
- [x] Verify iOS and macOS builds are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)